### PR TITLE
Bail ASI loop when inner expr() does not advance the cursor

### DIFF
--- a/feature/asi.js
+++ b/feature/asi.js
@@ -27,10 +27,16 @@ const MAX_ASI_DEPTH = 100;
 
 parse.asi = (a, p, expr, b, items) => {
   if (p >= lvl || asiDepth >= MAX_ASI_DEPTH) return;
+  // Bail if the inner expr didn't actually consume anything. Without this, a
+  // lookup handler that returns a non-array sentinel (e.g. switch.js's
+  // `reserve` flagging `case`/`default` inside a switch body) lets expr return
+  // a truthy token without advancing idx, and the outer ASI loop appends to its
+  // semicolon-list forever.
+  const beforeIdx = idx;
   asiDepth++;
   try { b = expr(lvl - .5); }
   finally { asiDepth--; }
-  if (!b) return;
+  if (!b || idx === beforeIdx) return;
   items = b?.[0] === ';' ? b.slice(1) : [b];
   return a?.[0] === ';' ? (a.push(...items), a) : [';', a, ...items];
 };

--- a/test/feature/control.js
+++ b/test/feature/control.js
@@ -155,6 +155,21 @@ test('control: switch basic', t => {
   is(ast[3][0], 'case')
 })
 
+// ASI inside a switch body: when an inner expr() call hits a reserved
+// keyword that signals "matched but did not consume" (e.g. case/default
+// while inSwitch), the ASI loop must stop. Without the no-progress guard,
+// the recursion appended to its semicolon-list until the array exceeded
+// its max length and threw `Invalid array length`.
+test('control: switch with multi-statement case bodies parses without ASI loop', t => {
+  is(parse(`switch (x) {
+    case 1:
+      a
+      b
+    case 2:
+      c
+  }`)[0], 'switch')
+})
+
 test('control: switch compile', t => {
   // Basic case match
   let ctx = { x: 1, y: 0 }


### PR DESCRIPTION
A switch body with multi-statement case branches throws `RangeError: Invalid array length` while parsing:

```js
parse(`switch (x) {
  case 1:
    a
    b
  case 2:
    c
}`)
```

Trace: infinite recursion through `asi → expr → asi → expr …` until the semicolon-list array overflows. The ASI loop continues whenever the inner `expr()` returns truthy, but a lookup handler is allowed to return a non-array sentinel to mean "matched but did not consume" — `feature/switch.js`'s `reserve('case')` does this when `case`/`default` appears inside a switch body, so ASI re-enters at the same cursor position.

Bail when the recursive `expr()` returns truthy without advancing `idx`. Regression test in `test/feature/control.js`. Suite stays green (294/294).
