### PR TITLE
Fix ASI after block expression semicolon

### DIFF
--- a/feature/asi.js
+++ b/feature/asi.js
@@ -53,8 +53,9 @@ parse.space = (cc, from) => {
 // this with no args.
 parse.enter = () => parse.newline = parse.semi = false;
 
-// `}` closes a block — outer context sees an implicit newline.
-parse.exit = (p, end) => { if (end === BLOCK_END) parse.newline = true; };
+// `}` closes a block — outer context sees an implicit newline. A hard semicolon
+// consumed inside the block belongs to that block.
+parse.exit = (p, end) => { if (end === BLOCK_END) parse.newline = true, parse.semi = false; };
 
 // Wrap iteration step: bail at high prec when `;\n` consumed; fire ASI before
 // `[`/`(` on a new line; fire ASI when no operator continues across newline.

--- a/test/jessie.js
+++ b/test/jessie.js
@@ -483,6 +483,12 @@ test('jessie: ASI return', () => {
   is(ast[2], 'x')
 })
 
+test('jessie: no ASI before . after block expression with semicolon', () => {
+  is(parse(`f(() => {
+    x;
+  }).g`), ['.', ['()', 'f', ['=>', ['()', null], ['{}', 'x']]], 'g'])
+})
+
 test('jessie: ASI custom precedence', async () => {
   const { prec, parse } = await import('../parse.js')
 


### PR DESCRIPTION
## Problem

A hard semicolon consumed inside a block expression can leak into the outer parse context. When the block expression is followed by member access, ASI can split before the member operator even though the semicolon belongs to the block body.

```js
f(() => {
  x;
}).g
```

## Fix

Clear the sticky hard-semicolon flag when exiting a block, while preserving the existing newline signal for the outer context.

## Validation

- `node test/jessie.js`
