### PR TITLE
Fix ASI switch case boundary recursion

### DIFF
--- a/feature/asi.js
+++ b/feature/asi.js
@@ -13,6 +13,7 @@ const lvl = prec.asi ?? prec[';'];
 // would leave previous ASI layers active.
 const baseSpace = parse._baseSpace ??= parse.space;
 const baseStep = parse._baseStep ??= parse.step;
+const isNode = a => Array.isArray(a) || typeof a === 'string';
 
 // LF immediately preceding the next non-space at i (used to detect `;\n`).
 const hasLineBreak = (i, c) => {
@@ -61,9 +62,10 @@ parse.exit = (p, end) => { if (end === BLOCK_END) parse.newline = true, parse.se
 // `[`/`(` on a new line; fire ASI when no operator continues across newline.
 parse.step = (a, p, cc, expr) => {
   if (parse.semi && p >= lvl) return false;
-  if (a && (parse.semi || ((cc === BRACKET || cc === PAREN) && lineBreak()))) return asi(a, p, expr) ?? null;
+  if (a && !isNode(a)) return null;
+  if (isNode(a) && (parse.semi || ((cc === BRACKET || cc === PAREN) && lineBreak()))) return asi(a, p, expr) ?? null;
   const nl = parse.newline;
-  return baseStep(a, p, cc, expr) ?? (a && nl ? asi(a, p, expr) ?? null : null);
+  return baseStep(a, p, cc, expr) ?? (isNode(a) && nl ? asi(a, p, expr) ?? null : null);
 };
 
 // Runaway-recursion guard: asi recurses once per consecutive statement in a

--- a/test/jessie.js
+++ b/test/jessie.js
@@ -694,6 +694,19 @@ test('jessie: ASI after arrow block body before next let', () => {
   )
 })
 
+test('jessie: ASI stops before switch case boundary', () => {
+  is(
+    parse(`switch (x) {
+      case 1:
+        a
+        b
+      case 2:
+        c
+    }`),
+    ['switch', 'x', ['case', [, 1], [';', 'a', 'b']], ['case', [, 2], 'c']]
+  )
+})
+
 test('jessie: if with bracket body (no block)', () => {
   is(parse('if (x) [a]'), ['if', 'x', ['[]', 'a']])
 })


### PR DESCRIPTION
## Problem

ASI can recurse at a `switch` case boundary when an expression in a case body is followed by another `case` or `default`. The switch parser uses a non-node sentinel to mark those reserved case-boundary keywords, but ASI treats any truthy value as a statement node and keeps trying to continue.

## Fix

Only run ASI continuation logic for actual AST nodes. Non-node sentinels now stop the current parse step instead of being fed back into ASI.

## Validation

- Parsed a multiline `switch` with multiple statements before the next `case`
- `node test/jessie.js`
