### PR TITLE
Fix ASI before accessor keyword identifiers

### DIFF
--- a/feature/accessor.js
+++ b/feature/accessor.js
@@ -7,13 +7,24 @@
 import { token, expr, skip, space, next, parse, cur, idx } from '../parse.js';
 
 const ASSIGN = 20;
+const LF = 10, CR = 13;
 const OPAREN = 40, CPAREN = 41, OBRACE = 123, CBRACE = 125;
+
+const hasLineTerminator = (from, to) => {
+  while (from < to) {
+    const c = cur.charCodeAt(from++);
+    if (c === LF || c === CR) return true;
+  }
+  return false;
+};
 
 // Shared parser for get/set — returns false if not valid accessor pattern (falls through to identifier)
 // Returns false (not undefined) to signal "fall through without setting reserved"
 const accessor = (kind) => a => {
   if (a) return; // not prefix
+  const from = idx;
   space();
+  if (parse.semi || hasLineTerminator(from, idx)) return false;
   const name = next(parse.id);
   if (!name) return false; // no property name = not accessor (e.g. `{ get: 1 }`)
   space();

--- a/test/jessie.js
+++ b/test/jessie.js
@@ -483,6 +483,13 @@ test('jessie: ASI return', () => {
   is(ast[2], 'x')
 })
 
+test('jessie: ASI separates returned accessor keyword identifiers', () => {
+  is(parse('return set;\nfor (const x of xs) { y(x) }'),
+    [';', ['return', 'set'], ['for', ['of', ['const', 'x'], 'xs'], ['()', 'y', 'x']]])
+  is(parse('return get;\nwhile (x) { y }'),
+    [';', ['return', 'get'], ['while', 'x', 'y']])
+})
+
 test('jessie: no ASI before . after block expression with semicolon', () => {
   is(parse(`f(() => {
     x;


### PR DESCRIPTION
## Problem

The `get`/`set` accessor parser can treat an identifier followed by a statement with a parenthesized head and block body as accessor syntax when a semicolon or line break separates them.

```js
return set;
for (const x of xs) { y(x) }
```

That should parse as two statements, but the accessor parser can read it as if it were `set for (...) { ... }` inside the returned expression.

## Fix

Reject accessor parsing when a semicolon boundary or line terminator appears between the `get`/`set` keyword candidate and the property name. In that case, `get`/`set` falls back to the normal identifier path and ASI can split the following statement correctly.

## Validation

- Direct parse check for `return set;` followed by a `for` block
- `node test/jessie.js`: 71 tests, 243 assertions
