### PR TITLE
Fix regex literal left brace parsing

### DIFF
--- a/test/feature/regex.js
+++ b/test/feature/regex.js
@@ -28,6 +28,11 @@ test('regex: eval', t => {
   is(run('"hello world".match(/\\w+/g)'), ['hello', 'world'])
 })
 
+test('regex: left brace source', t => {
+  is(parse('/a{/'), ['//', 'a{'])
+  is(parse('/a{2}/'), ['//', 'a{2}'])
+})
+
 test('regex: division disambiguation', t => {
   // Division when left operand exists
   is(run('4 / 2'), 2)


### PR DESCRIPTION
## Problem

Regex literals may contain a left brace that is not a repeat quantifier in non-unicode mode.

```js
/a{/.test("a{")
```

That should evaluate to `true`, while valid repeat quantifiers such as `/a{2}/` should continue to work.

## Fix

Add focused regex feature coverage for preserving a literal left brace in regex source alongside a valid `{2}` quantifier. The regex parser keeps the pattern source for `RegExp` evaluation, so this guards against treating every `{` as a quantifier boundary.

## Validation

- `node --import ./test/https-loader.js test/feature/regex.js`
- `pnpm run build`
- `pnpm test` (fails on existing unicode scaling stack overflows and networked perf fetch checks)