### PR TITLE
Fix regex literals starting with equals

### DIFF
--- a/feature/regex.js
+++ b/feature/regex.js
@@ -14,9 +14,9 @@ import { token, skip, err, next, idx, cur } from '../parse.js';
 const SLASH = 47, BSLASH = 92;
 
 token('/', 140, a => {
-  // left operand = division; `//` `/*` `/?` `/+` `/=` = not a regex start
+  // left operand = division or assignment; `//` `/*` `/?` `/+` = not a regex start
   const c = cur.charCodeAt(idx);
-  if (a || c === SLASH || c === 42 || c === 43 || c === 63 || c === 61) return;
+  if (a || c === SLASH || c === 42 || c === 43 || c === 63) return;
   const pattern = next(c => c === BSLASH ? 2 : c && c !== SLASH); // \x = 2 chars, else 1 until /
   cur.charCodeAt(idx) === SLASH || err('Unterminated regex');
   skip();

--- a/test/feature/regex.js
+++ b/test/feature/regex.js
@@ -1,6 +1,7 @@
 import test, { is, throws } from 'tst'
 import { parse, compile } from '../../subscript.js'
 import '../../feature/regex.js'
+import '../../eval/regex.js'
 
 const run = (code, ctx = {}) => compile(parse(code))(ctx)
 
@@ -40,6 +41,8 @@ test('regex: division disambiguation', t => {
 test('regex: in expressions', t => {
   is(run('x.match(/\\d+/)', { x: 'abc123def' })[0], '123')
   is(run('x.replace(/a/g, "b")', { x: 'aaa' }), 'bbb')
+  is(run('x.replace(/=/g, "")', { x: 'a=b=c' }), 'abc')
+  is(run('x.replace(/=>/g, ":")', { x: 'a=>b=>c' }), 'a:b:c')
 })
 
 test('regex: JSON serializable', t => {


### PR DESCRIPTION
## Problem

Regex literals whose pattern starts with `=` are valid in expression positions, but the parser rejects them before reading the regex body.

```js
value.replace(/=/g, "")
value.replace(/=>/g, ":")
```

Those should parse and evaluate as regex literals, while compound assignment such as `a /= b` should still parse as assignment.

## Fix

Allow `=` as the first regex pattern character when the `/` token is parsed in a prefix-expression position. The existing left-operand check still leaves division and `/=` assignment handling to their operator parsers.

Add focused regex feature coverage for `replace(/=/g, ...)` and `replace(/=>/g, ...)`.

## Validation

- `node --input-type=module -e 'import { parse } from "./subscript.js"; import "./feature/regex.js"; console.log(JSON.stringify(parse("x.replace(/=/g, \\\"\\\")"))); console.log(JSON.stringify(parse("x.replace(/=>/g, \\\":\\\")"))); console.log(JSON.stringify(parse("a /= b")))'`
- `node --import ./test/https-loader.js test/feature/regex.js`