### PR TITLE
Fix reserved words in member access

### DIFF
--- a/feature/access.js
+++ b/feature/access.js
@@ -2,15 +2,29 @@
  * Property access: a.b, a[b], a(b), [1,2,3] - parse half
  * For private fields (#x), see class.js
  */
-import { access, binary } from '../parse.js';
+import { access, cur, err, expr, idx, next, parse, skip, token } from '../parse.js';
 
 const ACCESS = 170;
+const HASH = 35, _0 = 48, _9 = 57;
 
 // a[b]
 access('[]', ACCESS);
 
 // a.b
-binary('.', ACCESS);
+token('.', ACCESS, a => {
+  if (!a) return;
+
+  parse.space();
+  if (cur.charCodeAt(idx) === HASH) {
+    skip();
+    const id = next(parse.id);
+    return id ? ['.', a, '#' + id] : err('Expected property name');
+  }
+
+  const cc = cur.charCodeAt(idx);
+  const prop = cc >= _0 && cc <= _9 ? expr(ACCESS) : next(parse.id) || expr(ACCESS);
+  return ['.', a, prop || err('Expected property name')];
+});
 
 // a(b,c,d), a()
 access('()', ACCESS);

--- a/test/jessie.js
+++ b/test/jessie.js
@@ -24,6 +24,11 @@ test('jessie: inherits justin', () => {
   is(parse('{a: 1}'), ['{}', [':', 'a', [, 1]]])
 })
 
+test('jessie: reserved words in member access', () => {
+  is(parse('record.function.kind'), ['.', ['.', 'record', 'function'], 'kind'])
+  is(parse('record.class.name'), ['.', ['.', 'record', 'class'], 'name'])
+})
+
 // === variables ===
 
 test('jessie: variables', () => {


### PR DESCRIPTION
## Problem

Dot member access parses the property name through the general expression parser. That lets keyword handlers consume reserved words after `.`, so some valid property names fail to parse in member chains.

## Fix

Parse dot member property names directly when the next token is identifier-like. Keep existing support for private names, and continue falling back to expression parsing for legacy numeric member forms.

Add focused Jessie coverage for reserved words after dot access.

## Validation

- Targeted parse smoke test covering reserved-word dot access, private field access, and numeric member access
